### PR TITLE
Add a template parameter to manage usage of neutron l3_ha option

### DIFF
--- a/compute.yaml
+++ b/compute.yaml
@@ -172,6 +172,10 @@ parameters:
         The tunnel types for the Neutron tenant network. To specify multiple
         values, use a comma separated string, like so: 'gre,vxlan'
     default: 'gre'
+  NeutronL3HA:
+    default: 'False'
+    description: Wheter to enable l3-agent HA
+    type: string
   NovaApiHost:
     type: string
     default: ''  # Has to be here because of the ignored empty value bug
@@ -335,6 +339,7 @@ resources:
         neutron_physical_bridge: {get_param: NeutronPhysicalBridge}
         neutron_public_interface: {get_param: NeutronPublicInterface}
         neutron_password: {get_param: NeutronPassword}
+        neutron_l3_ha: {get_param: NeutronL3HA}
         admin_password: {get_param: AdminPassword}
         rabbit_host: {get_param: RabbitHost}
         rabbit_username: {get_param: RabbitUserName}

--- a/controller.yaml
+++ b/controller.yaml
@@ -183,6 +183,10 @@ parameters:
     default: 'dhcp-option-force=26,1400'
     description: Dnsmasq options for neutron-dhcp-agent. The default value here forces MTU to be set to 1400 to account for the gre tunnel overhead.
     type: string
+  NeutronL3HA:
+    default: 'False'
+    description: Wheter to enable l3-agent HA
+    type: string
   NeutronEnableTunnelling:
     type: string
     default: "True"
@@ -424,6 +428,7 @@ resources:
           flat-networks: {get_param: NeutronFlatNetworks}
           host: {get_input: controller_virtual_ip}
           metadata_proxy_shared_secret: unset
+          l3_ha: {get_param: NeutronL3HA}
           ovs:
             enable_tunneling: {get_input: neutron_enable_tunneling}
             local_ip: {get_input: controller_host}

--- a/nova-compute-config.yaml
+++ b/nova-compute-config.yaml
@@ -35,6 +35,7 @@ resources:
           flat-networks: {get_input: neutron_flat_networks}
           host: {get_input: neutron_host}
           ovs_db: {get_input: neutron_dsn}
+          l3_ha: {get_input: neutron_l3_ha}
           ovs:
             local_ip: {get_input: neutron_local_ip}
             tenant_network_type: {get_input: neutron_tenant_network_type}

--- a/nova-compute-instance.yaml
+++ b/nova-compute-instance.yaml
@@ -144,6 +144,10 @@ parameters:
         The tunnel types for the Neutron tenant network. To specify multiple
         values, use a comma separated string, like so: 'gre,vxlan'
     type: string
+  NeutronL3HA:
+    default: 'False'
+    description: Wheter to enable l3-agent HA
+    type: string
   NovaApiHost:
     type: string
   NovaComputeDriver:
@@ -242,6 +246,7 @@ resources:
         neutron_physical_bridge: {get_param: NeutronPhysicalBridge}
         neutron_public_interface: {get_param: NeutronPublicInterface}
         neutron_password: {get_param: NeutronPassword}
+        neutron_l3_ha: {get_param: NeutronL3HA}
         admin_password: {get_param: AdminPassword}
         rabbit_host: {get_param: RabbitHost}
         rabbit_username: {get_param: RabbitUserName}

--- a/overcloud-source.yaml
+++ b/overcloud-source.yaml
@@ -273,6 +273,10 @@ parameters:
         The tunnel types for the Neutron tenant network. To specify multiple
         values, use a comma separated string, like so: 'gre,vxlan'
     type: string
+  NeutronL3HA:
+    default: 'False'
+    description: Wheter to enable l3-agent HA
+    type: string
   NovaComputeDriver:
     default: libvirt.LibvirtDriver
     type: string
@@ -420,6 +424,8 @@ resources:
             get_param: HypervisorNeutronPublicInterface
         NeutronBridgeMappings:
             get_param: NeutronBridgeMappings
+        NeutronL3HA:
+            get_param: NeutronL3HA
   NovaCompute0AllNodesDeployment:
     type: FileInclude
     Path: nova-compute-instance.yaml
@@ -578,6 +584,7 @@ resources:
           flat-networks: {get_param: NeutronFlatNetworks}
           host: {get_input: controller_virtual_ip}
           metadata_proxy_shared_secret: unset
+          l3_ha: {get_param: NeutronL3HA}
           ovs:
             enable_tunneling: 'True'
             local_ip:

--- a/overcloud-without-mergepy.yaml
+++ b/overcloud-without-mergepy.yaml
@@ -111,6 +111,10 @@ parameters:
         The tunnel types for the Neutron tenant network. To specify multiple
         values, use a comma separated string, like so: 'gre,vxlan'
     type: string
+  NeutronL3HA:
+    default: 'False'
+    description: Wheter to enable l3-agent HA
+    type: string
   NovaPassword:
     default: unset
     description: The password for the nova service account, used by nova-api.
@@ -468,6 +472,7 @@ resources:
           NeutronPublicInterfaceRawDevice: {get_param: NeutronPublicInterfaceRawDevice}
           NeutronPassword: {get_param: NeutronPassword}
           NeutronDnsmasqOptions: {get_param: NeutronDnsmasqOptions}
+          NeutronL3HA: {get_param: NeutronL3HA}
           NeutronNetworkType: {get_param: NeutronNetworkType}
           NeutronTunnelTypes: {get_param: NeutronTunnelTypes}
           NovaPassword: {get_param: NovaPassword}
@@ -523,6 +528,7 @@ resources:
           NeutronPassword: {get_param: NeutronPassword}
           NeutronPhysicalBridge: {get_param: HypervisorNeutronPhysicalBridge}
           NeutronPublicInterface: {get_param: HypervisorNeutronPublicInterface}
+          NeutronL3HA: {get_param: NeutronL3HA}
           NovaApiHost: {get_attr: [ControlVirtualIP, fixed_ips, 0, ip_address]}
           NovaComputeDriver: {get_param: NovaComputeDriver}
           NovaComputeExtraConfig: {get_param: NovaComputeExtraConfig}


### PR DESCRIPTION
This change will allow for the enablement of Neutron L3 routers HA
via the new NeutronL3HA parameter.

It is a (crafted) cherry-pick of https://review.openstack.org/#/c/145766/1
